### PR TITLE
fix a typo in the documentation of mbinder_rank

### DIFF
--- a/lib/bindlib.ml
+++ b/lib/bindlib.ml
@@ -466,7 +466,7 @@ let mbinder_constant : ('a,'b) mbinder -> bool =
 (** [mbinder_closed b] indicates whether [b] is closed. *)
 let mbinder_closed : ('a,'b) mbinder -> bool = fun b -> b.mb_rank = 0
 
-(* [mbinder_rank b] gives the number of free variables contained in [b]. *)
+(** [mbinder_rank b] gives the number of free variables contained in [b]. *)
 let mbinder_rank : ('a,'b) mbinder -> int = fun b -> b.mb_rank
 
 (** [dummy_box] can be used for initialising structures like arrays. Note that


### PR DESCRIPTION
Just fixing a typo

mbinder_rank documentation does not appear in https://lepigre.fr/ocaml-bindlib/odoc/bindlib/Bindlib/index.html due to the missing "*"