### PR TITLE
fix mbinder_constant

### DIFF
--- a/lib/bindlib.ml
+++ b/lib/bindlib.ml
@@ -461,7 +461,7 @@ let mbinder_occurs : ('a,'b) mbinder -> bool array = fun b -> b.mb_binds
 (** [mbinder_constant b] indicates whether the [mbinder] [b] is constant. This
     means that none of its variables are used. *)
 let mbinder_constant : ('a,'b) mbinder -> bool =
-  fun b -> Array.fold_left (||) false b.mb_binds
+  fun b -> not (Array.fold_left (||) false b.mb_binds)
 
 (** [mbinder_closed b] indicates whether [b] is closed. *)
 let mbinder_closed : ('a,'b) mbinder -> bool = fun b -> b.mb_rank = 0


### PR DESCRIPTION
If I'm not mistaken, the value returned by mbinder_constant should be inversed to have the same behavior as binder_constant
