### PR TITLE
Add unboxing annotation to the [any_var] type.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         run: |
           eval $(opam env)
           opam update
-          opam install dune
           opam upgrade
           opam pin add -n -k path bindlib .
           opam install --deps-only -d -t bindlib

--- a/bindlib.opam
+++ b/bindlib.opam
@@ -16,7 +16,9 @@ homepage: "https://github.com/rlepigre/bindlib"
 bug-reports: "https://github.com/rlepigre/bindlib/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {>= "2.7" & >= "2.7.0" & build}
+  "dune" {>= "2.7" & build}
+  "timed" {= "1.0" & with-test}
+  "earley" {= "3.0.0" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -22,4 +22,7 @@
     λ-calculus or quantified formulas.")
  (depends
    (ocaml (>= 4.02.0))
-   (dune  (and (>= 2.7.0) :build))))
+   (dune :build)
+   (timed (and (= 1.0) :with-test))
+   (earley (and (= 3.0.0) :with-test))
+   (odoc :with-doc)))

--- a/lib/bindlib.ml
+++ b/lib/bindlib.ml
@@ -123,8 +123,11 @@ and 'a var = {
   var_box    : 'a box;       (* Variable as a boxed object. *)
 }
 
-and any_var = V : 'a var -> any_var (* [@@ocaml.unboxed] *)
-(* FIXME uncomment the attribute for OCaml >= 4.11.0. *)
+(* Variable of any type (using an existential). In principle, this constructor
+   can be unboxed since it has a single constructor.  However, this only works
+   starting from OCaml 4.11.0. The annotation is erased for prior versions. *)
+and any_var = V : 'a var -> any_var
+[@@unboxed]
 
 let name_of x = x.var_name
 let hash_var x = Hashtbl.hash (`HVar, x.var_key)

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,9 @@
  (name bindlib)
  (public_name bindlib)
  (synopsis "An efficient representation of binders")
+ (preprocess
+  (action
+   (run ocaml %{project_root}/lib/pp.ml %{ocaml_version} %{input-file})))
+ (preprocessor_deps pp.ml)
+ (modules bindlib)
  (wrapped false))

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -1,0 +1,27 @@
+(** Preprocessor for removing the "[@@unboxed]" attribute on [Bindlib.any_var]
+    if the OCaml version is lower that 4.11. *)
+
+let iter_lines : (string -> unit) -> string -> unit = fun f file ->
+  let ic = open_in file in
+  try while true do f (input_line ic) done with End_of_file -> close_in ic
+
+(** OCaml version given as first command line argument. *)
+let version =
+  match String.split_on_char '.' Sys.argv.(1) with
+  | major :: minor :: _ -> (int_of_string major, int_of_string minor)
+  | _                   -> assert false
+
+(** File to process given as second command line argument. *)
+let input_file = Sys.argv.(2)
+
+let print_line : string -> unit = fun line ->
+  print_string line; print_char '\n'
+
+let print_line_if_not_unbox : string -> unit = fun line ->
+  if String.trim line <> "[@@unboxed]" then print_line line
+
+let _ =
+  let handle_line =
+    if version < (4, 11) then print_line_if_not_unbox else print_line
+  in
+  iter_lines handle_line input_file


### PR DESCRIPTION
Since this only works from OCaml 4.11.0, we use ~~sed~~ __a preprocessor__ to remove the annotation on older versions.