### PR TITLE
change mb_mkfree to an array of functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,16 @@
+## https://github.com/craff
+Christophe Raffalli <christophe@raffalli.eu>         craff <christophe@raffalli.eu>
+Christophe Raffalli <christophe@raffalli.eu>         raffalli <raffalli@univ-savoie.fr>
+Christophe Raffalli <christophe@raffalli.eu>         christophe.raffalli <christophe.raffalli@univ-savoie.fr>
+Christophe Raffalli <christophe@raffalli.eu>         craff <christophe@raffalli.eu>
+Christophe Raffalli <christophe@raffalli.eu>         craff <raffalli@univ-savoie.fr>
+Christophe Raffalli <christophe@raffalli.eu>         Christophe Raffalli <raffalli@univ-savoie.fr>
+Christophe Raffalli <christophe@raffalli.eu>         Christophe Raffalli <christophe@raffalli.eu>
+
+## https://github.com/rlepigre
+Rodolphe Lepigre <lepigre@mpi-sws.org>               Rodolphe Lepigre <rodolphe.lepigre@inria.fr>
+Rodolphe Lepigre <lepigre@mpi-sws.org>               rodolphe.lepigre <rodolphe.lepigre@univ-savoie.fr>
+Rodolphe Lepigre <lepigre@mpi-sws.org>               Rodolphe Lepigre <rodolphe.lepigre@univ-savoie.fr>
+
+## https://github.com/adelaett
+Alain <alain@inria.fr>                               alain <90894311+adelaett@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ You can either pin the repository with opam or run the following.
 make
 make install
 ```
+
+Contributors
+------------
+
+Main contributors:
+- Christophe Raffalli ([@craff](https://github.com/craff), author of the first version)
+- Rodolphe Lepigre ([@rlepigre](https://github.com/rlepigre))
+
+The project received additional contributions from:
+- Alain ([@adelaett](https://github.com/adelaett))
+- Rémi Nollet ([@rnollet](https://github.com/rnollet))
+- Qiancheng Fu ([@qcfu-bu](https://github.com/qcfu-bu))

--- a/lib/bindlib.mli
+++ b/lib/bindlib.mli
@@ -621,6 +621,7 @@ val raw_binder : string -> bool -> int -> ('a var -> 'a)
 
 (** [raw_mbinder names binds rank mk_free value] is similar  to  [raw_binder],
     but it is applied to a multiple binder. As for [raw_binder], this function
-    has to be considered unsafe because the user must enforce invariants. *)
-val raw_mbinder : string array -> bool array -> int -> ('a var -> 'a)
+    has to be considered unsafe because the user must enforce invariants. Note
+    that [names], [binds] and [mk_free] should have the same lenght. *)
+val raw_mbinder : string array -> bool array -> int -> ('a var -> 'a) array
   -> ('a array -> 'b) -> ('a,'b) mbinder


### PR DESCRIPTION
Closes issue #34. Other than `raw_mbinder`, all user facing interfaces remain the same.